### PR TITLE
Add list_protocols endpoint to web_service

### DIFF
--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -384,6 +384,10 @@ class Gui(QMainWindow):
                     Thread(target=lambda: self.start_experiment()).start()
                 return ok
 
+            @web_service.expose
+            def list_protocols():
+                return sorted(map(str, Path('.').glob('protocols/**/*.json')))
+
             web_service.start(host, int(port))
 
     def change_acquisition_preview(self):


### PR DESCRIPTION
This enables a nice quality of life improvements when starting imaging from the robot system. Endpoint looks like this:
```
$ ssh devserver curl -s 10.10.0.95:5050/squid/list_protocols
{
  "value": [
    "protocols/U2OS_PE_MMJ.json",
    "protocols/U2OS_PE_MMJ_TEST1.json",
    "protocols/U2OS_PE_MMJ_TEST2.json",
    "protocols/U2OS_PE_cbcs0556.json",
    "protocols/YM_L1.json",
    "protocols/YM_L2.json",
    "protocols/illum.json",
    "protocols/p53_PE.json",
    "protocols/short_hog.json",
    "protocols/short_jump_nov_2022.json",
    "protocols/short_pe.json",
    "protocols/short_pe2.json",
    "protocols/specs3k_2023_04_03.json",
    "protocols/stage-eval.json"
  ]
}
```